### PR TITLE
Update smtp-enum.md [command fix]

### DIFF
--- a/ejpt/assessment-methodologies/3-enumeration/smtp-enum.md
+++ b/ejpt/assessment-methodologies/3-enumeration/smtp-enum.md
@@ -161,6 +161,7 @@ mail from: admin@attacker.xyz
 rcpt to: root@openmailbox.xyz
 data
 Subject: Hello Root
+
 Hello,
 This is a fake mail sent using telnet command.
 From admin


### PR DESCRIPTION
In SMTP, when sending email manually using telnet or nc, a blank line is required after the Subject: line to separate the email headers from the body.